### PR TITLE
Support for hex code containing an alpha component (eg. #ff00ff3c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ WFColorCode supports the following color code styles.
 ```swift
 /// color code type
 enum ColorCodeType: Int {
+    case hexRGBa    // #ffffffff
     case hex        // #ffffff
     case shortHex   // #fff
     case cssRGB     // rgb(255,255,255)

--- a/Sources/ColorCode/NSColor+ColorCode.swift
+++ b/Sources/ColorCode/NSColor+ColorCode.swift
@@ -31,9 +31,12 @@ import Foundation
 import AppKit.NSColor
 
 public enum ColorCodeType: Int, CaseIterable {
-    
+
+    /// 8-digit hexadecimal color code with # symbol. For example: `#ffffffff`
+    case hexRGBa = 1
+
     /// 6-digit hexadecimal color code with # symbol. For example: `#ffffff`
-    case hex = 1
+    case hex
     
     /// 3-digit hexadecimal color code with # symbol. For example: `#fff`
     case shortHex
@@ -84,6 +87,8 @@ public extension NSColor {
             .compactMap({ type -> (ColorCodeType, NSTextCheckingResult)? in
                 let pattern: String = {
                     switch type {
+                    case .hexRGBa:
+                        return "^#[0-9a-fA-F]{8}$"
                     case .hex:
                         return "^#[0-9a-fA-F]{6}$"
                     case .shortHex:
@@ -111,6 +116,13 @@ public extension NSColor {
         
         // create color from result
         switch detectedType {
+
+        case .hexRGBa:
+            let hex = Int(code.dropFirst(), radix: 16)!
+            let af = CGFloat(hex & 0x000000FF) / 255
+            let newHex = hex >> 8
+            self.init(hex: newHex, alpha: af)
+
         case .hex:
             let hex = Int(code.dropFirst(), radix: 16)!
             self.init(hex: hex)
@@ -225,6 +237,10 @@ public extension NSColor {
         switch type {
         case .hex:
             return String(format: "#%02x%02x%02x", r, g, b)
+            
+        case .hexRGBa:
+            let a = Int(round(255 * alpha))
+            return String(format: "#%02x%02x%02x%02x", r, g, b, a)
             
         case .shortHex:
             return String(format: "#%1x%1x%1x", r / 16, g / 16, b / 16)

--- a/Tests/ColorCodeTests/ColorCodeTests.swift
+++ b/Tests/ColorCodeTests/ColorCodeTests.swift
@@ -34,10 +34,12 @@ import ColorCode
 class ColorCodeTests: XCTestCase {
 
     func testColorCreation() {
-        
-        let whiteColor = NSColor.white.usingColorSpaceName(.calibratedRGB)
+        let whiteColor = NSColor(calibratedRed: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
         var type: ColorCodeType?
-        
+
+        XCTAssertEqual(NSColor(colorCode: "#ffffffff", type: &type), whiteColor)
+        XCTAssertEqual(type, .hexRGBa)
+
         XCTAssertEqual(NSColor(colorCode: "#ffffff", type: &type), whiteColor)
         XCTAssertEqual(type, .hex)
         
@@ -71,16 +73,16 @@ class ColorCodeTests: XCTestCase {
     
     
     func testWhite() {
-        
-        let color = NSColor.white.usingColorSpaceName(.calibratedRGB)
-        
-        XCTAssertEqual(color?.colorCode(type: .hex), "#ffffff")
-        XCTAssertEqual(color?.colorCode(type: .shortHex), "#fff")
-        XCTAssertEqual(color?.colorCode(type: .cssRGB), "rgb(255,255,255)")
-        XCTAssertEqual(color?.colorCode(type: .cssRGBa), "rgba(255,255,255,1)")
-        XCTAssertEqual(color?.colorCode(type: .cssHSL), "hsl(0,0%,100%)")
-        XCTAssertEqual(color?.colorCode(type: .cssHSLa), "hsla(0,0%,100%,1)")
-        XCTAssertEqual(color?.colorCode(type: .cssKeyword), "White")
+        let color = NSColor(calibratedRed: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+
+        XCTAssertEqual(color.colorCode(type: .hexRGBa), "#ffffffff")
+        XCTAssertEqual(color.colorCode(type: .hex), "#ffffff")
+        XCTAssertEqual(color.colorCode(type: .shortHex), "#fff")
+        XCTAssertEqual(color.colorCode(type: .cssRGB), "rgb(255,255,255)")
+        XCTAssertEqual(color.colorCode(type: .cssRGBa), "rgba(255,255,255,1)")
+        XCTAssertEqual(color.colorCode(type: .cssHSL), "hsl(0,0%,100%)")
+        XCTAssertEqual(color.colorCode(type: .cssHSLa), "hsla(0,0%,100%,1)")
+        XCTAssertEqual(color.colorCode(type: .cssKeyword), "White")
     }
     
     
@@ -109,6 +111,21 @@ class ColorCodeTests: XCTestCase {
         XCTAssertEqual(type, .hex)
         XCTAssertEqual(color?.colorCode(type: .hex), "#0066aa")
         XCTAssertEqual(color?.colorCode(type: .shortHex), "#06a")
+    }
+
+    func testHexWithAlpha() {
+        var type: ColorCodeType?
+        guard let color = NSColor(colorCode: "#2566aa10", type: &type) else {
+            XCTAssert(false, "Unable to create color using hex alpha")
+            return
+        }
+        XCTAssertEqual(type, .hexRGBa)
+        XCTAssertEqual(color.redComponent, CGFloat(0x25) / 255.0)
+        XCTAssertEqual(color.greenComponent, CGFloat(0x66) / 255.0)
+        XCTAssertEqual(color.blueComponent, CGFloat(0xaa) / 255.0)
+        XCTAssertEqual(color.alphaComponent, CGFloat(0x10) / 255.0)
+        XCTAssertEqual(color.colorCode(type: .hex), "#2566aa")
+        XCTAssertEqual(color.colorCode(type: .shortHex), "#26a")
     }
     
     


### PR DESCRIPTION
Added support for hex code containing an alpha component (eg. #ff00ff3c)

Usage:

```swift
let partiallyTransparentWhite = NSColor(colorCode: "#ffffff55")!
```

In order to support this, I needed to re-order the enum so that the 'hexRGBa' case came before 'hex' (as both hex and shortHex are a subset of hexRGBa).

Also fixed compile deprecation warnings using `usingColorSpaceName(.calibratedRGB)`