### PR TITLE
Fill in platform value

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "ColorCode",
+    platforms: [
+        .macOS("10.9"),
+    ],
     products: [
         .library(name: "ColorCode", targets: ["ColorCode"]),
     ],


### PR DESCRIPTION
Hello! I love what you've done here. I'm doing something similar in my app, but this looks way, way better :)

I think it would be really cool if we could find ways to collaborate, since we both work on text editors. My project is here: www.chimehq.com. And, the libraries we've open sourced are at github.com/chimehq. More are on the way :)

But, I figured this would be a great place to start! Absolutely no pressure. If it works out, great. If not, no worries!

I noticed that the platform is not specified in the package, so I thought I'd add it. However, it looks like 10.10 is the oldest OS the package manager supports with built-in constants. Even the generated Xcode project won't support less than 10.10. So, I used to a string to specify the platform version. That's documented as supported here: https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md#supportedplatform

What do you think? I use Carthage for all my dependencies right now, but moving to SPM seems like a reasonable thing to do now that it's built into Xcode.